### PR TITLE
Fix the problem that Python cannot find modules

### DIFF
--- a/01A.构建运行环境（默认源）.bat
+++ b/01A.构建运行环境（默认源）.bat
@@ -4,4 +4,5 @@ python -m venv venv
 call venv\Scripts\activate.bat
 pip install -r .\requirements.txt
 pip install torch --extra-index-url https://download.pytorch.org/whl/cu113
+type .\venv\Lib\site-packages\__init__.py
 pause

--- a/01B.构建运行环境（国内源）.bat
+++ b/01B.构建运行环境（国内源）.bat
@@ -3,4 +3,5 @@ python -m venv venv
 call venv\Scripts\activate.bat
 pip install -r .\requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
 pip install torch --extra-index-url https://download.pytorch.org/whl/cu113
+type .\venv\Lib\site-packages\__init__.py
 pause


### PR DESCRIPTION
In some cases, the script does not automatically create the __init__.py file
The environment is Python 3.10.5
it will cause a fatal error on initialization.