### PR TITLE
fix: update Miniconda download method and add error handling

### DIFF
--- a/01A.构建运行环境（默认源）.bat
+++ b/01A.构建运行环境（默认源）.bat
@@ -10,7 +10,13 @@ IF %ERRORLEVEL% NEQ 0 (
         @RD /S /Q %~dp0envs\miniconda3
         mkdir %~dp0envs\miniconda3
         echo "Downloading miniconda..."
-        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://repo.anaconda.com/miniconda/Miniconda3-py310_24.9.2-0-Windows-x86_64.exe', '.\envs\miniconda3.exe')"
+        
+        powershell -Command "iwr -uri 'https://repo.anaconda.com/miniconda/Miniconda3-py310_24.9.2-0-Windows-x86_64.exe' -OutFile '.\envs\miniconda3.exe'"
+        if not exist %~dp0envs\miniconda3.exe (
+            echo "Failed to download Miniconda installer."
+            pause
+            exit /b 1
+        )
 
         echo "Installling minconda..."
         start /wait "" %~dp0envs\miniconda3.exe /S /AddToPath=0 /RegisterPython=0 /InstallationType=JustMe /D=%~dp0envs\miniconda3

--- a/01B.构建运行环境（国内源）.bat
+++ b/01B.构建运行环境（国内源）.bat
@@ -10,7 +10,13 @@ IF %ERRORLEVEL% NEQ 0 (
         @RD /S /Q %~dp0envs\miniconda3
         mkdir %~dp0envs\miniconda3
         echo "Downloading miniconda..."
-        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://repo.anaconda.com/miniconda/Miniconda3-py310_24.9.2-0-Windows-x86_64.exe', '.\envs\miniconda3.exe')"
+        
+        powershell -Command "iwr -uri 'https://repo.anaconda.com/miniconda/Miniconda3-py310_24.9.2-0-Windows-x86_64.exe' -OutFile '.\envs\miniconda3.exe'"
+        if not exist %~dp0envs\miniconda3.exe (
+            echo "Failed to download Miniconda installer."
+            pause
+            exit /b 1
+        )
 
         echo "Installling minconda..."
         start /wait "" %~dp0envs\miniconda3.exe /S /AddToPath=0 /RegisterPython=0 /InstallationType=JustMe /D=%~dp0envs\miniconda3


### PR DESCRIPTION
use iwr ( Invoke-WebRequest ) instead of Net.WebClient. Fix 403 error.
```
         powershell -Command "(New-Object Net.WebClient).DownloadFile('https://repo.anaconda.com/miniconda/Miniconda3-py310_24.9.2-0-Windows-x86_64.exe', '.\envs\miniconda3.exe')"                                  
╰─❯                                                                                            
Exception calling "DownloadFile" with "2" argument(s): "The remote server returned an error: (403) Forbidd
en."
At line:1 char:1
+ (New-Object Net.WebClient).DownloadFile('https://repo.anaconda.com/mi ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException
```